### PR TITLE
chore: prepare @multica-ai/dsh-runtime npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Multica DSH Runtime
 
-Private, out-of-tree runtime bridge between Multica and the public
+Out-of-tree runtime bridge between Multica and the public
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). It exposes
 a versioned JSONL protocol over stdio and composes over
 `@deepseek-ai/dsh-base`. It does not require changes to DeepSeek Harness.
 
-![DeepSeek Harness runtime online in Multica](docs/images/multica-dsh-runtime.png)
+![DeepSeek Harness runtime online in Multica](https://unpkg.com/@multica-ai/dsh-runtime@0.1.0/docs/images/multica-dsh-runtime.png)
 
 ## Privacy
 
@@ -14,6 +14,37 @@ a versioned JSONL protocol over stdio and composes over
 - Never commit API keys, MCP secrets, session logs, or generated profiles.
 - DSH telemetry is disabled by the bundle patch.
 - stdout is protocol-only; diagnostics go to stderr.
+
+## Installation
+
+Install the runtime bundle into a dedicated DSH profile:
+
+```bash
+dsh plugin --profile multica add @multica-ai/dsh-runtime@0.1.0
+```
+
+Verify the installed profile before starting Multica:
+
+```bash
+dsh --profile multica --probe
+dsh --profile multica --list-models
+```
+
+Multica discovers the profile only after `--probe` reports protocol version 1.
+The plugin and Multica must use the same `DSH_HOME` when a non-default DSH home
+is configured. For a non-standard DSH installation, point the daemon at its
+launcher:
+
+```bash
+export MULTICA_DSH_PATH=/absolute/path/to/dsh
+```
+
+To update or remove the bundle:
+
+```bash
+dsh plugin --profile multica update @multica-ai/dsh-runtime
+dsh plugin --profile multica remove @multica-ai/dsh-runtime
+```
 
 ## Local development
 
@@ -39,13 +70,6 @@ The plugin supports:
 dsh --profile multica --probe
 dsh --profile multica --list-models
 dsh --profile multica --stdio
-```
-
-Multica discovers the profile only after `--probe` returns protocol version 1.
-For a non-standard DSH installation, point the daemon at its launcher:
-
-```bash
-export MULTICA_DSH_PATH=/absolute/path/to/dsh
 ```
 
 The runtime contract includes:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Out-of-tree runtime bridge between Multica and the public
 a versioned JSONL protocol over stdio and composes over
 `@deepseek-ai/dsh-base`. It does not require changes to DeepSeek Harness.
 
-![DeepSeek Harness runtime online in Multica](https://unpkg.com/@multica-ai/dsh-runtime@0.1.0/docs/images/multica-dsh-runtime.png)
+![DeepSeek Harness runtime online in Multica](https://raw.githubusercontent.com/multica-ai/dsh-multica-runtime/main/docs/images/multica-dsh-runtime.png)
 
 ## Privacy
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing to npm
+
+The package is published publicly as `@multica-ai/dsh-runtime`. The source
+repository may remain private, but every file listed by `npm pack` becomes
+public when the package is published.
+
+## Preconditions
+
+- Work from a clean `main` branch synchronized with `origin/main`.
+- Confirm the version in `package.json` has never been published.
+- Confirm `UNLICENSED` is still the intended license policy for the release.
+- Log in to npm with an account allowed to publish public packages under the
+  `@multica-ai` scope.
+- Do not place API keys, MCP credentials, session logs, `.env` files, or local
+  DSH profiles in the package.
+
+## Build and inspect
+
+```bash
+pnpm install --frozen-lockfile
+pnpm release:check
+```
+
+`release:check` runs type checking, tests, a clean TypeScript build, and an npm
+pack dry run. Inspect the printed file list and package size before continuing.
+
+Create the exact artifact that will be tested and published:
+
+```bash
+pnpm pack --pack-destination /absolute/path/to/release-artifacts
+```
+
+Install that tarball into an empty DSH profile and verify at least:
+
+```bash
+dsh plugin --profile multica-release-test add /absolute/path/to/package.tgz
+dsh --profile multica-release-test --probe
+dsh --profile multica-release-test --list-models
+```
+
+The release candidate should also pass the opt-in Multica real-runtime smoke,
+including a first turn and session resume, using credentials supplied only in
+the test process environment.
+
+## Publish
+
+After the artifact and clean-install checks pass:
+
+```bash
+npm whoami
+npm publish
+```
+
+`publishConfig.access` makes the scoped package public. `prepublishOnly` reruns
+the full check before npm accepts the package.
+
+Verify the registry result before creating a Git tag or GitHub release:
+
+```bash
+npm view @multica-ai/dsh-runtime version dist-tags --json
+dsh plugin --profile multica-registry-test add @multica-ai/dsh-runtime@0.1.0
+dsh --profile multica-registry-test --probe
+```
+
+Only after registry installation succeeds should the matching `v0.1.0` Git
+tag and GitHub release be created.

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,5 +1,5 @@
-# Private Multica runtime surface over dsh-base. It intentionally exposes no
-# HTTP listener and disables DSH telemetry so private task content never leaves
+# Headless Multica runtime surface over dsh-base. It intentionally exposes no
+# HTTP listener and disables DSH telemetry so task content never leaves
 # the machine except through the explicitly selected model and MCP providers.
 
 - id: hmr

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "files": [
     "dist",
     "cordis.patch.yml",
-    "docs/images/multica-dsh-runtime.png",
     "README.md"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
   "name": "@multica-ai/dsh-runtime",
-  "version": "0.1.0-private.1",
-  "private": true,
-  "description": "Private DeepSeek Harness runtime bridge for Multica",
+  "version": "0.1.0",
+  "description": "DeepSeek Harness runtime bridge for Multica",
+  "keywords": [
+    "deepseek",
+    "dsh",
+    "multica",
+    "runtime"
+  ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dsh-external/dsh-multica-runtime.git"
+    "url": "git+https://github.com/multica-ai/dsh-multica-runtime.git"
+  },
+  "homepage": "https://github.com/multica-ai/dsh-multica-runtime#readme",
+  "bugs": {
+    "url": "https://github.com/multica-ai/dsh-multica-runtime/issues"
   },
   "type": "module",
   "main": "dist/index.js",
@@ -21,13 +30,20 @@
   "files": [
     "dist",
     "cordis.patch.yml",
+    "docs/images/multica-dsh-runtime.png",
     "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "check": "pnpm typecheck && pnpm test && pnpm build"
+    "check": "pnpm typecheck && pnpm test && pnpm build",
+    "prepack": "pnpm build",
+    "prepublishOnly": "pnpm check",
+    "release:check": "pnpm check && npm pack --dry-run"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "engines": {
     "node": "^22.19.0 || >=24.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 import { realpath } from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
@@ -35,7 +36,17 @@ import { installMulticaTerminalEnvironment } from './environment.js'
 export const name = 'multica-dsh-runtime'
 export const inject = ['cmdlineArgs', 'agents', 'agentDefaultModel', 'sessions', 'llm']
 
-const PLUGIN_VERSION = '0.1.0-private.1'
+function loadPluginVersion(): string {
+  const metadata = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as { version?: unknown }
+  if (typeof metadata.version !== 'string' || metadata.version.length === 0) {
+    throw new Error('package.json does not declare a valid version')
+  }
+  return metadata.version
+}
+
+const PLUGIN_VERSION = loadPluginVersion()
 
 interface ActiveRun {
   command: ExecuteCommand


### PR DESCRIPTION
## Summary

- prepare `@multica-ai/dsh-runtime@0.1.0` for public npm distribution
- add public package metadata, repository links, `publishConfig`, and guarded npm lifecycle scripts
- document registry installation, profile verification, updates, removal, and the release checklist
- derive the runtime probe version from `package.json` so package and protocol metadata cannot drift
- keep the README screenshot hosted by the public repository, trim it from the runtime tarball, and remove stale private-release wording

## Validation

- `pnpm release:check`
- `npm publish --dry-run`
- inspected the exact 19-file, 18.3 kB tarball and scanned it for credentials and local source paths
- installed the generated tarball into a fresh DSH `0.1.0-rc.6` environment
- verified `dsh --profile multica --probe` reports plugin version `0.1.0` and protocol version `1`
- verified runtime model and thinking-level discovery
- passed the opt-in Multica real-runtime smoke for both the first turn and session resume

## Publication status

This PR does not publish the package. The package name is not currently present in the public npm registry. A publisher still needs to authenticate an npm account with access to the `@multica-ai` scope and explicitly confirm that retaining `UNLICENSED` is the intended license policy before running `npm publish`.
