### PR TITLE
fix: exempt the task token on the scrub instance DSH really spawns through

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,6 +1,26 @@
+import { realpathSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import type { Context } from '@deepseek-ai/cordis'
-import { SENSITIVE_ENV_PATTERN } from '@deepseek-ai/dsh-subprocess'
+import { SENSITIVE_ENV_PATTERN, scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
 import { multicaTerminalEnvironment } from './task-env.js'
+
+/** The one credential name Multica forwards through DSH's scrub. */
+const TASK_TOKEN_KEY = 'MULTICA_TOKEN'
+
+/** The slice of `@deepseek-ai/dsh-subprocess` this module patches and probes. */
+interface ScrubModule {
+  SENSITIVE_ENV_PATTERN: RegExp
+  scrubbedParentEnv(): Record<string, string>
+}
+
+/** What {@link installMulticaTerminalEnvironment} actually achieved. */
+export interface TerminalEnvironmentReport {
+  /** How many distinct scrub instances now exempt the task token. */
+  patched: number
+  /** Whether the task token survives the scrub DSH is going to apply. */
+  forwarded: boolean
+}
 
 /**
  * DSH deliberately removes credential-shaped ambient variables from every
@@ -9,26 +29,100 @@ import { multicaTerminalEnvironment } from './task-env.js'
  * reads and writes to the current task. A user PAT or model-provider
  * credential must never pass through this path.
  */
-/**
- * Exempt the exact task-token name from DSH's credential-name scrub. This is
- * installed at the scrub policy itself because agent-local PTY realms resolve
- * the subprocess service through a scoped proxy; decorating the host service
- * does not affect those already-composed realms. Every other `*TOKEN*`,
- * `*KEY*`, `*SECRET*`, and `*PASSWORD*` variable remains scrubbed.
- */
-export function installMulticaTerminalEnvironment(ctx: Context): void {
-  const explicitEnvironment = multicaTerminalEnvironment(process.env)
-  if (explicitEnvironment.MULTICA_TOKEN === undefined) return
 
-  const originalTest = SENSITIVE_ENV_PATTERN.test
+/**
+ * Exempt the exact task-token name from one scrub pattern. This is installed
+ * at the scrub policy itself because agent-local PTY realms resolve the
+ * subprocess service through a scoped proxy; decorating the host service does
+ * not affect those already-composed realms. Every other `*TOKEN*`, `*KEY*`,
+ * `*SECRET*`, and `*PASSWORD*` variable remains scrubbed.
+ * @param pattern - the `SENSITIVE_ENV_PATTERN` of one loaded dsh-subprocess.
+ * @returns a disposer restoring the untouched matcher.
+ */
+function exemptTaskToken(pattern: RegExp): () => void {
+  const originalTest = pattern.test
   const patchedTest = function (this: RegExp, value: string): boolean {
-    if (value.toUpperCase() === 'MULTICA_TOKEN') return false
+    if (value.toUpperCase() === TASK_TOKEN_KEY) return false
     return originalTest.call(this, value)
   }
-  SENSITIVE_ENV_PATTERN.test = patchedTest
-  ctx.effect(() => () => {
-    if (SENSITIVE_ENV_PATTERN.test === patchedTest) SENSITIVE_ENV_PATTERN.test = originalTest
-  }, 'multica task environment forwarding')
+  pattern.test = patchedTest
+  return () => {
+    if (pattern.test === patchedTest) pattern.test = originalTest
+  }
+}
+
+/**
+ * Exempt the task token on every scrub instance supplied, deduplicated by
+ * object identity.
+ *
+ * The plural matters. Patching a matcher only affects the module instance that
+ * matcher belongs to, and a bridge loaded through a `link:` dependency resolves
+ * its own copy of `@deepseek-ai/dsh-subprocess` rather than the copy the DSH
+ * launcher loaded. Patching only the statically imported one left the real
+ * scrub untouched, the token stripped, and every in-task `multica` command
+ * refused for want of a `mat_` credential (MUL-6186). Nothing about that
+ * failure was visible until an agent tried to use the CLI.
+ * @param patterns - scrub matchers to exempt; duplicates are patched once.
+ * @returns the instance count and a disposer restoring all of them.
+ */
+export function exemptTaskTokenOn(
+  patterns: Iterable<RegExp>,
+): { patched: number, dispose: () => void } {
+  const disposers = [...new Set(patterns)].map(exemptTaskToken)
+  return {
+    patched: disposers.length,
+    dispose: () => {
+      for (const dispose of disposers) dispose()
+    },
+  }
+}
+
+/**
+ * Resolve the dsh-subprocess instance the DSH launcher itself loaded, so the
+ * exemption reaches the scrub that actually runs no matter how this plugin was
+ * installed.
+ * @param entrypoint - the launcher script, normally `process.argv[1]`.
+ * @returns the launcher's module, or undefined when it cannot be reached.
+ */
+async function hostScrubModule(entrypoint: string | undefined): Promise<ScrubModule | undefined> {
+  if (entrypoint === undefined || entrypoint.trim() === '') return undefined
+  try {
+    // realpathSync is load-bearing: `dsh` is normally a bin symlink, Node
+    // leaves argv[1] as the link, and a link in a bare bin directory resolves
+    // no node_modules chain of its own.
+    const specifier = createRequire(realpathSync(entrypoint)).resolve('@deepseek-ai/dsh-subprocess')
+    return await import(pathToFileURL(specifier).href) as ScrubModule
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Let the current task's `mat_` token — and nothing else — reach the shell
+ * tools, on whichever dsh-subprocess instances are reachable from here.
+ * @param ctx - the Cordis context whose disposal restores the scrub.
+ * @param entrypoint - the launcher script to resolve DSH's own copy from.
+ * @returns what was installed, or undefined when there is no task token to forward.
+ */
+export async function installMulticaTerminalEnvironment(
+  ctx: Context,
+  entrypoint: string | undefined = process.argv[1],
+): Promise<TerminalEnvironmentReport | undefined> {
+  const explicitEnvironment = multicaTerminalEnvironment(process.env)
+  if (explicitEnvironment[TASK_TOKEN_KEY] === undefined) return undefined
+
+  const host = await hostScrubModule(entrypoint)
+  const { patched, dispose } = exemptTaskTokenOn(
+    host === undefined
+      ? [SENSITIVE_ENV_PATTERN]
+      : [SENSITIVE_ENV_PATTERN, host.SENSITIVE_ENV_PATTERN],
+  )
+  ctx.effect(() => dispose, 'multica task environment forwarding')
+
+  // Probe the scrub the shell tools will really call rather than trusting that
+  // the patch landed. A silent miss here costs the whole task.
+  const scrub = host?.scrubbedParentEnv ?? scrubbedParentEnv
+  return { patched, forwarded: scrub()[TASK_TOKEN_KEY] !== undefined }
 }
 
 export { multicaTerminalEnvironment } from './task-env.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,7 +419,15 @@ async function execute(ctx: Context, active: ActiveRun): Promise<number> {
 }
 
 async function stdio(ctx: Context): Promise<number> {
-  installMulticaTerminalEnvironment(ctx)
+  const forwarding = await installMulticaTerminalEnvironment(ctx)
+  if (forwarding !== undefined && !forwarding.forwarded) {
+    // Fail loudly at boot instead of twenty seconds later, as an opaque
+    // "requires a task-scoped mat_ token" refusal on the agent's first
+    // `multica` call (MUL-6186).
+    writeDiagnostic(
+      'MULTICA_TOKEN is not reaching model-spawned subprocesses; in-task multica commands will be refused',
+    )
+  }
   const activeRef: { current?: ActiveRun; finished: boolean } = { finished: false }
   ctx.on('session/event', (session, event: SessionEvent) => {
     if (activeRef.current !== undefined) observeSessionEvent(activeRef.current, session, event)

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Context } from '@deepseek-ai/cordis'
+import { scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
+import { exemptTaskTokenOn, installMulticaTerminalEnvironment } from '../src/environment.js'
+
+/** DSH's own credential-name matcher, cloned so a test never patches the real one. */
+function scrubPattern(): RegExp {
+  return /KEY|PASSWORD|SECRET|TOKEN/i
+}
+
+/** A Cordis stand-in that records effect disposers so a test can unwind them. */
+function fakeContext(): { context: Context, disposers: (() => void)[], dispose: () => void } {
+  const disposers: (() => void)[] = []
+  const context = {
+    effect(callback: () => () => void) {
+      disposers.push(callback())
+    },
+  } as unknown as Context
+  return {
+    context,
+    disposers,
+    dispose: () => {
+      for (const dispose of disposers) dispose()
+    },
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('exemptTaskTokenOn', () => {
+  it('exempts the task token on every distinct scrub instance', () => {
+    const bridgeCopy = scrubPattern()
+    const hostCopy = scrubPattern()
+
+    const { patched, dispose } = exemptTaskTokenOn([bridgeCopy, hostCopy])
+
+    // The MUL-6186 regression: patching one loaded copy of dsh-subprocess
+    // leaves any other loaded copy — the one DSH actually spawns through —
+    // still scrubbing the token.
+    expect(patched).toBe(2)
+    expect(bridgeCopy.test('MULTICA_TOKEN')).toBe(false)
+    expect(hostCopy.test('MULTICA_TOKEN')).toBe(false)
+
+    dispose()
+    expect(bridgeCopy.test('MULTICA_TOKEN')).toBe(true)
+    expect(hostCopy.test('MULTICA_TOKEN')).toBe(true)
+  })
+
+  it('patches a repeated instance once', () => {
+    const pattern = scrubPattern()
+
+    const { patched, dispose } = exemptTaskTokenOn([pattern, pattern])
+    dispose()
+
+    expect(patched).toBe(1)
+    expect(pattern.test('MULTICA_TOKEN')).toBe(true)
+  })
+
+  it('keeps every other credential-shaped name scrubbed', () => {
+    const pattern = scrubPattern()
+
+    const { dispose } = exemptTaskTokenOn([pattern])
+
+    expect(pattern.test('DEEPSEEK_API_KEY')).toBe(true)
+    expect(pattern.test('MULTICA_USER_TOKEN')).toBe(true)
+    expect(pattern.test('AWS_SECRET_ACCESS_KEY')).toBe(true)
+    expect(pattern.test('DB_PASSWORD')).toBe(true)
+    expect(pattern.test('PATH')).toBe(false)
+    dispose()
+  })
+})
+
+describe('installMulticaTerminalEnvironment', () => {
+  it('forwards the task token through the scrub the shell tools call', async () => {
+    vi.stubEnv('MULTICA_TOKEN', 'mat_task-token')
+    vi.stubEnv('DEEPSEEK_API_KEY', 'provider-secret')
+    const ctx = fakeContext()
+
+    const report = await installMulticaTerminalEnvironment(ctx.context)
+
+    expect(report?.forwarded).toBe(true)
+    expect(report?.patched).toBeGreaterThanOrEqual(1)
+    const env = scrubbedParentEnv()
+    expect(env.MULTICA_TOKEN).toBe('mat_task-token')
+    expect(env.DEEPSEEK_API_KEY).toBeUndefined()
+
+    ctx.dispose()
+    expect(scrubbedParentEnv().MULTICA_TOKEN).toBeUndefined()
+  })
+
+  it('installs nothing when the token is not task-scoped', async () => {
+    vi.stubEnv('MULTICA_TOKEN', 'mul_user-token')
+    const ctx = fakeContext()
+
+    await expect(installMulticaTerminalEnvironment(ctx.context)).resolves.toBeUndefined()
+
+    expect(ctx.disposers).toHaveLength(0)
+    expect(scrubbedParentEnv().MULTICA_TOKEN).toBeUndefined()
+  })
+
+  it('still exempts the imported scrub when the launcher cannot be resolved', async () => {
+    vi.stubEnv('MULTICA_TOKEN', 'mat_task-token')
+    const ctx = fakeContext()
+
+    const report = await installMulticaTerminalEnvironment(ctx.context, '/nonexistent/dsh')
+
+    expect(report).toEqual({ patched: 1, forwarded: true })
+    ctx.dispose()
+  })
+})


### PR DESCRIPTION
Fixes the DeepSeek Harness quick-create failure reported in MUL-6186:
`agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token`.

## Root cause

DSH removes credential-shaped variable **names** from every subprocess it
spawns for the model — `/KEY|PASSWORD|SECRET|TOKEN/i` in `scrubbedParentEnv()`
(`@deepseek-ai/dsh-subprocess`), applied by `childEnv()` in
`dsh-subprocess-local`. `MULTICA_TOKEN` matches `TOKEN`.

This bridge already exempted the name by monkey-patching
`SENSITIVE_ENV_PATTERN.test` — but a patched matcher only affects the module
instance it belongs to, and two copies of `@deepseek-ai/dsh-subprocess` were
loaded:

| | instance |
|---|---|
| bridge patched | `multica-dsh-runtime/node_modules/.pnpm/@deepseek-ai+dsh-subprocess@…` |
| DSH spawned through | `…/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-subprocess` |

The exemption never reached the scrub that actually ran:

```
same module instance?          false
bridge copy patched?           true
dsh copy patched?              false
MULTICA_TOKEN survives scrub?  false
MULTICA_AGENT_ID survives?     true
```

That asymmetry is the whole bug. The bash child kept `MULTICA_AGENT_ID`,
`MULTICA_TASK_ID`, `MULTICA_DAEMON_PORT` and `MULTICA_TASK_CONFIG_ROOT` but
lost `MULTICA_TOKEN`, so the Multica CLI saw "I am inside a daemon task" with
no `mat_` credential and refused.

Quick create surfaced it first because its entire job is one
`multica issue create`. Chat looked healthy only because chat replies stream
back over the stdio protocol and never shell out — **every** DSH task needing
the CLI was affected, including the closing `multica issue comment add` on a
normal issue task.

## The change

- Resolve `@deepseek-ai/dsh-subprocess` from the launcher that loaded this
  plugin, and exempt the token on **every distinct instance** (deduplicated by
  object identity). This holds under both the linked dev layout and a
  deduplicated published install, instead of depending on module-instance
  identity that no longer holds the moment a copy sneaks in.
  `realpathSync` on the entrypoint is load-bearing: `dsh` is normally a bin
  symlink, Node leaves `argv[1]` as the link, and resolving from a bare bin
  directory finds no `node_modules` chain.
- Probe the host scrub after installing and report whether the token really
  survives; `stdio()` writes a diagnostic when it does not. This failure was
  completely invisible until an agent tried to use the CLI twenty seconds into
  a task.
- `installMulticaTerminalEnvironment` is now async and returns a report.
  `stdio()` is the only caller.

The exemption stays exactly as narrow as before: only `MULTICA_TOKEN`, with
every other `*KEY*` / `*SECRET*` / `*PASSWORD*` / `*TOKEN*` still scrubbed.

## Verification

`pnpm check` passes (typecheck, 14 tests, build). New `tests/environment.test.ts`
covers multi-instance exemption, dedupe, non-`mat_` tokens, unresolvable
launchers, and that other credential names stay scrubbed.

Because the unit tests run inside this repo — where both resolutions collapse
to one instance — the fix was also verified against the real two-copy layout,
loading the built bridge through the profile symlink exactly as DSH does:

```
two distinct copies loaded: true
before — MULTICA_TOKEN in child env: undefined
report: { patched: 2, forwarded: true }
after  — MULTICA_TOKEN in child env: mat_faketoken_for_verify
after  — MULTICA_AGENT_ID: agent-1
after  — DEEPSEEK_API_KEY still scrubbed: true
after  — OTHER_TOKEN still scrubbed: true
disposed — MULTICA_TOKEN in child env: undefined
```

Remaining validation is a live run: retry quick create against a DSH agent and
confirm a normal issue task can post its closing comment.

## Follow-up worth raising upstream

Patching another package's internals is the real fragility here. A supported
passthrough allowlist in `dsh-subprocess` would retire this patch entirely.
`ctx.shellEnv` is the sanctioned mechanism but cannot help — it rejects any key
that is not `DSH_*`.
