### PR TITLE
feat: add task contract, progress reporting, and local writeback for DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The runtime contract includes:
 - narrowly forwards only Multica's server-minted `mat_` task token into DSH's
   otherwise credential-scrubbed shell, so in-task `multica` commands retain
   task attribution without exposing model-provider credentials.
+- optionally forwards `MULTICA_ISSUE_ID` from `ExecuteCommand.issue_id`, so the
+  task can write local progress and acceptance state back to its Multica issue;
+  see `docs/task-local-writeback.md`.
 
 The local `.local/` tree is ignored. It may hold an isolated DSH home and a
 development launcher, but neither belongs in source control.

--- a/docs/task-local-writeback.md
+++ b/docs/task-local-writeback.md
@@ -1,0 +1,93 @@
+# 任务内本地回写闭环
+
+`dsh-multica-runtime` 仅负责把 Multica 任务的 `issue_id` 通过
+`MULTICA_ISSUE_ID` 环境变量透传给模型生成的子进程。任务内是否回写、何时回写，
+由任务自身通过 `multica` CLI 和本目录中的脚本完成，平台编排不需要任何改动。
+
+## 前置条件
+
+1. 任务内已存在有效的 `MULTICA_TOKEN`（`mat_` 前缀）。运行时会按既有安全策略
+   只透传该 token，不修改任何 provider credential 的脱敏逻辑。
+2. 下发 `execute` 命令时携带可选 `issue_id` 字段，例如：
+
+   ```json
+   {
+     "v": 1,
+     "type": "execute",
+     "request_id": "req-1",
+     "cwd": "/work",
+     "prompt": "修复问题",
+     "issue_id": "049c05e8-70ed-4c43-8ffa-9a313bb94c50"
+   }
+   ```
+
+   运行时收到该字段后，会把 `process.env.MULTICA_ISSUE_ID` 设置为该值。
+3. `multica` CLI 在任务内可用，并继承 `MULTICA_TOKEN` 与 `MULTICA_ISSUE_ID`。
+
+## 进度回写
+
+任务执行过程中，把 `progress.jsonl` 中最新一条含 `phase` 或 `last_artifact`
+的记录写入 issue metadata：
+
+```bash
+node scripts/multica-local-progress.mjs .multica/progress.jsonl
+```
+
+脚本会依次执行：
+
+```bash
+multica issue metadata set <issue-id> --key phase --value <phase> --type string
+multica issue metadata set <issue-id> --key last_artifact --value <artifact> --type string
+```
+
+`progress.jsonl` 每行是一个 JSON 对象，脚本按顺序扫描，后出现的
+`phase` / `last_artifact` 覆盖先出现的值；只要二者至少存在一个，脚本即成功。
+
+## 验收回写
+
+任务完成并跑完 `required_checks` 后调用：
+
+```bash
+node scripts/multica-local-acceptance.mjs \
+  --result passed \
+  --log .multica/acceptance.log
+```
+
+失败时：
+
+```bash
+node scripts/multica-local-acceptance.mjs \
+  --result failed \
+  --log .multica/acceptance.log \
+  --summary "required_checks 中 pnpm test 退出码为 1"
+```
+
+脚本行为：
+
+- `passed`：将 issue 置为 `in_review`。
+- `failed`：将 issue 置为 `blocked`。
+- 生成评论文件到 `.multica/acceptance-comment.md`，并通过
+  `multica issue comment add <issue-id> --content-file <file>` 发布。
+- 评论中包含结果、摘要、失败原因和日志摘要。
+
+## 幂等与防抖动
+
+- 状态修改前先读取 `multica issue get`，只有当前状态与目标状态不同才调用
+  `multica issue status`，避免无意义的状态切换。
+- 评论发布前先比较 issue metadata 中的 `local_acceptance_fingerprint`。
+  指纹由 `result + summary + log` 计算得到；指纹相同则跳过评论，避免重复评论。
+- 评论发布成功后才把新指纹写入 `local_acceptance_fingerprint`。如果评论失败，
+  下次重跑仍会尝试发布。
+- 若日志内容或摘要变化，指纹会变化，此时允许发布一条新的验收评论；这是有意
+  的“可覆盖”，便于对失败修复后再次报告。
+
+## 与平台原生 acceptance 消费共存
+
+平台未来如果在 WIN-94 中直接消费 runtime 出站的 `acceptance` 帧，本地脚本仍可
+安全运行：
+
+- 本地脚本只使用 issue metadata 和 issue comment/status 这些用户态接口，不读取
+  或修改 runtime 的 protocol 帧。
+- 状态与评论均为幂等；平台回写与本地回写到达顺序不同，也不会造成状态抖动。
+- 平台侧应继续消费 runtime 的 `progress` / `result.acceptance`，本地 metadata
+  只是给当前 Multica 上层提供可读的短状态，不替代平台数据源。

--- a/docs/task-local-writeback.md
+++ b/docs/task-local-writeback.md
@@ -1,14 +1,16 @@
-# 任务内本地回写闭环
+# In-task local writeback loop
 
-`dsh-multica-runtime` 仅负责把 Multica 任务的 `issue_id` 通过
-`MULTICA_ISSUE_ID` 环境变量透传给模型生成的子进程。任务内是否回写、何时回写，
-由任务自身通过 `multica` CLI 和本目录中的脚本完成，平台编排不需要任何改动。
+`dsh-multica-runtime` only forwards a Multica task's `issue_id` to model-spawned
+subprocesses through the `MULTICA_ISSUE_ID` environment variable. Whether and when
+a task writes back is decided by the task itself via the `multica` CLI and the
+scripts in this directory; no platform orchestration changes are required.
 
-## 前置条件
+## Prerequisites
 
-1. 任务内已存在有效的 `MULTICA_TOKEN`（`mat_` 前缀）。运行时会按既有安全策略
-   只透传该 token，不修改任何 provider credential 的脱敏逻辑。
-2. 下发 `execute` 命令时携带可选 `issue_id` 字段，例如：
+1. A valid `MULTICA_TOKEN` (with the `mat_` prefix) already exists inside the task.
+   The runtime forwards only this token following existing security policy and does
+   not change any provider-credential scrubbing logic.
+2. The `execute` command carries an optional `issue_id` field, for example:
 
    ```json
    {
@@ -16,36 +18,39 @@
      "type": "execute",
      "request_id": "req-1",
      "cwd": "/work",
-     "prompt": "修复问题",
+     "prompt": "Fix the issue",
      "issue_id": "049c05e8-70ed-4c43-8ffa-9a313bb94c50"
    }
    ```
 
-   运行时收到该字段后，会把 `process.env.MULTICA_ISSUE_ID` 设置为该值。
-3. `multica` CLI 在任务内可用，并继承 `MULTICA_TOKEN` 与 `MULTICA_ISSUE_ID`。
+   When the runtime receives this field, it sets `process.env.MULTICA_ISSUE_ID` to
+   that value.
+3. The `multica` CLI is available inside the task and inherits `MULTICA_TOKEN` and
+   `MULTICA_ISSUE_ID`.
 
-## 进度回写
+## Progress writeback
 
-任务执行过程中，把 `progress.jsonl` 中最新一条含 `phase` 或 `last_artifact`
-的记录写入 issue metadata：
+During task execution, write the latest `progress.jsonl` record containing `phase`
+or `last_artifact` into issue metadata:
 
 ```bash
 node scripts/multica-local-progress.mjs .multica/progress.jsonl
 ```
 
-脚本会依次执行：
+The script runs, in order:
 
 ```bash
 multica issue metadata set <issue-id> --key phase --value <phase> --type string
 multica issue metadata set <issue-id> --key last_artifact --value <artifact> --type string
 ```
 
-`progress.jsonl` 每行是一个 JSON 对象，脚本按顺序扫描，后出现的
-`phase` / `last_artifact` 覆盖先出现的值；只要二者至少存在一个，脚本即成功。
+Each line in `progress.jsonl` is a JSON object. The script scans lines in order,
+and later `phase` / `last_artifact` values overwrite earlier ones. It succeeds as
+long as at least one of the two fields is present.
 
-## 验收回写
+## Acceptance writeback
 
-任务完成并跑完 `required_checks` 后调用：
+After the task finishes and runs `required_checks`, call:
 
 ```bash
 node scripts/multica-local-acceptance.mjs \
@@ -53,41 +58,47 @@ node scripts/multica-local-acceptance.mjs \
   --log .multica/acceptance.log
 ```
 
-失败时：
+On failure:
 
 ```bash
 node scripts/multica-local-acceptance.mjs \
   --result failed \
   --log .multica/acceptance.log \
-  --summary "required_checks 中 pnpm test 退出码为 1"
+  --summary "pnpm test in required_checks exited with code 1"
 ```
 
-脚本行为：
+Script behavior:
 
-- `passed`：将 issue 置为 `in_review`。
-- `failed`：将 issue 置为 `blocked`。
-- 生成评论文件到 `.multica/acceptance-comment.md`，并通过
-  `multica issue comment add <issue-id> --content-file <file>` 发布。
-- 评论中包含结果、摘要、失败原因和日志摘要。
+- `passed`: sets the issue to `in_review`.
+- `failed`: sets the issue to `blocked`.
+- Generates a comment file at `.multica/acceptance-comment.md` and publishes it with
+  `multica issue comment add <issue-id> --content-file <file>`.
+- The comment includes the result, summary, failure reason, and log summary.
 
-## 幂等与防抖动
+## Idempotency and anti-flapping
 
-- 状态修改前先读取 `multica issue get`，只有当前状态与目标状态不同才调用
-  `multica issue status`，避免无意义的状态切换。
-- 评论发布前先比较 issue metadata 中的 `local_acceptance_fingerprint`。
-  指纹由 `result + summary + log` 计算得到；指纹相同则跳过评论，避免重复评论。
-- 评论发布成功后才把新指纹写入 `local_acceptance_fingerprint`。如果评论失败，
-  下次重跑仍会尝试发布。
-- 若日志内容或摘要变化，指纹会变化，此时允许发布一条新的验收评论；这是有意
-  的“可覆盖”，便于对失败修复后再次报告。
+- Before changing status, the script reads `multica issue get` and only calls
+  `multica issue status` when the current status differs from the target, avoiding
+  meaningless status transitions.
+- Before publishing a comment, it compares `local_acceptance_fingerprint` in issue
+  metadata. The fingerprint is computed from `result + summary + log`; if it is
+  unchanged, the comment is skipped to avoid duplicates.
+- The new fingerprint is written to `local_acceptance_fingerprint` only after the
+  comment is published successfully. If the comment fails, the next retry still
+  attempts to publish it.
+- If the log content or summary changes, the fingerprint changes, allowing a new
+  acceptance comment. This intentional "overwrite" behavior lets the task report
+  again after fixing a failure.
 
-## 与平台原生 acceptance 消费共存
+## Coexisting with platform-native acceptance consumption
 
-平台未来如果在 WIN-94 中直接消费 runtime 出站的 `acceptance` 帧，本地脚本仍可
-安全运行：
+If the platform later consumes the runtime's outgoing `acceptance` frame directly
+(WIN-94), the local scripts can still run safely:
 
-- 本地脚本只使用 issue metadata 和 issue comment/status 这些用户态接口，不读取
-  或修改 runtime 的 protocol 帧。
-- 状态与评论均为幂等；平台回写与本地回写到达顺序不同，也不会造成状态抖动。
-- 平台侧应继续消费 runtime 的 `progress` / `result.acceptance`，本地 metadata
-  只是给当前 Multica 上层提供可读的短状态，不替代平台数据源。
+- The local scripts only use user-level interfaces such as issue metadata and issue
+  comment/status; they do not read or modify runtime protocol frames.
+- Status changes and comments are idempotent; even if platform writeback and local
+  writeback arrive in different orders, status will not flap.
+- The platform side should continue to consume the runtime's `progress` /
+  `result.acceptance`. Local metadata only provides a readable short status for the
+  current Multica upper layer and does not replace the platform data source.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "cordis.patch.yml",
     "README.md"
   ],

--- a/package.json
+++ b/package.json
@@ -50,22 +50,43 @@
     "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
   },
   "peerDependenciesMeta": {
-    "@deepseek-ai/cordis": { "optional": true },
-    "@deepseek-ai/cordis-plugin-loader": { "optional": true },
-    "@deepseek-ai/dsh-agent": { "optional": true },
-    "@deepseek-ai/dsh-agent-default-model": { "optional": true },
-    "@deepseek-ai/dsh-cmdline": { "optional": true },
-    "@deepseek-ai/dsh-llm": { "optional": true },
-    "@deepseek-ai/dsh-mcp-client": { "optional": true },
-    "@deepseek-ai/dsh-session": { "optional": true },
-    "@deepseek-ai/dsh-subprocess": { "optional": true },
-    "@deepseek-ai/dsh-user-approval": { "optional": true }
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/cordis-plugin-loader": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-agent": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-agent-default-model": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-cmdline": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-mcp-client": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-subprocess": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-user-approval": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
     "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-mcp-client": "^0.1.0-rc.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
-        version: 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+        version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader':
         specifier: ^1.0.2
         version: 1.0.2(@deepseek-ai/cordis@4.0.1)
@@ -20,6 +20,9 @@ importers:
       '@deepseek-ai/dsh-agent-default-model':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(8bffb997b64260f42aff4629c695b626)
+      '@deepseek-ai/dsh-agent-presets':
+        specifier: ^0.1.0-rc.6
+        version: 0.1.0-rc.6(4c20af7d23bdb1bbe92fd5e1e7ddef5d)
       '@deepseek-ai/dsh-cmdline':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
@@ -52,6 +55,12 @@ importers:
         version: 4.1.8(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1))
 
 packages:
+
+  '@deepseek-ai/cordis-plugin-include@1.0.6':
+    resolution: {integrity: sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
 
   '@deepseek-ai/cordis-plugin-loader@1.0.2':
     resolution: {integrity: sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==}
@@ -86,6 +95,21 @@ packages:
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
       '@deepseek-ai/dsh-settings': ^0.1.0-rc.6
 
+  '@deepseek-ai/dsh-agent-presets@0.1.0-rc.6':
+    resolution: {integrity: sha512-LtDz0TYE7YNhJOhMDZ8s45xQG57bWF4F1SN3tjYDosaBdINIRTxJ0O80BC+KeliqFDw071ZNOzTUEelwEAIx7w==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/cordis-plugin-include': ^1.0.6
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-atomic-write': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-home-paths': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-settings': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+
   '@deepseek-ai/dsh-agent@0.1.0-rc.6':
     resolution: {integrity: sha512-vtqq2pWTrzn0dKfj5kREZRpP82AwtGjGx9V1lYnKvF+Uc/a8zyWbSvjDE7V1d3YQAQJzs2cWO31hURWDekDXIA==}
     peerDependencies:
@@ -96,6 +120,12 @@ packages:
       '@deepseek-ai/dsh-session': ^0.1.0-rc.6
       '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
       '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-atomic-write@0.1.0-rc.6':
+    resolution: {integrity: sha512-Ot/2aygDzWuN4ypUkDJA6MpSlGbcvzzKnWAms0lg+2WUtPZr7O0cGb83K3TEO2NoAu0LJfVxlbo8Eya3tDaFtw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
 
   '@deepseek-ai/dsh-attachment@0.1.0-rc.6':
     resolution: {integrity: sha512-3P6N17NQ8jqSQGzeCs+svCIqArU8oq0YmgEAo+axN9aVuUDferWU4DLRSX59UGpmyldX4LQn81toA+c+DqMcHg==}
@@ -119,6 +149,12 @@ packages:
 
   '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6':
     resolution: {integrity: sha512-aw8D4IOeMo11A3uxQeE4LFoW3bvaQnVkGFqqtS+lsINDARrOCJHXLUgecoKpys+Lc5erZZ4UQDnymJmL4OCcKA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-home-paths@0.1.0-rc.6':
+    resolution: {integrity: sha512-gIiUBmqB3L8inFr+hvjZv2/i6EVJOHIHCHg7bBFVhcl4HDK94+8wUCXTLGy80tcuISzIQiIaLuJq/NhSmV9Amw==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
@@ -282,36 +318,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.3':
     resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.3':
     resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.3':
     resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.3':
     resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.3':
     resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
@@ -392,6 +434,9 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -614,6 +659,10 @@ packages:
   jose@6.2.8:
     resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -655,24 +704,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1003,32 +1056,56 @@ packages:
 
 snapshots:
 
+  '@deepseek-ai/cordis-plugin-include@1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/cosmokit': 1.8.2
+      js-yaml: 4.3.1
+
   '@deepseek-ai/cordis-plugin-loader@1.0.2(@deepseek-ai/cordis@4.0.1)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cosmokit': 1.8.2
 
-  '@deepseek-ai/cordis@4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)':
+  '@deepseek-ai/cordis@4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)':
     dependencies:
       '@deepseek-ai/cosmokit': 1.8.2
       '@standard-schema/spec': 1.1.0
     optionalDependencies:
+      '@deepseek-ai/cordis-plugin-include': 1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/cosmokit@1.8.2': {}
 
   '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.6(8bffb997b64260f42aff4629c695b626)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-settings': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
 
+  '@deepseek-ai/dsh-agent-presets@0.1.0-rc.6(4c20af7d23bdb1bbe92fd5e1e7ddef5d)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis-plugin-include': 1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
+      '@deepseek-ai/dsh-atomic-write': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-home-paths': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/dsh-settings': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
+      js-yaml: 4.3.1
+
   '@deepseek-ai/dsh-agent@0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
@@ -1036,36 +1113,46 @@ snapshots:
       '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
 
+  '@deepseek-ai/dsh-atomic-write@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
   '@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-cmdline@0.1.0-rc.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-home-paths@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/schemastery': 3.18.1
 
   '@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-attachment': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
@@ -1074,7 +1161,7 @@ snapshots:
 
   '@deepseek-ai/dsh-mcp-client@0.1.0-rc.6(d9ec2605a01b4fe7b4e01a4a94e11c5c)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-subprocess': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
@@ -1089,12 +1176,12 @@ snapshots:
 
   '@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
@@ -1103,19 +1190,19 @@ snapshots:
 
   '@deepseek-ai/dsh-settings@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/schemastery': 3.18.1
 
   '@deepseek-ai/dsh-subprocess@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
@@ -1123,12 +1210,12 @@ snapshots:
 
   '@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-tools@0.1.0-rc.6(f8724372086ccc1457fc84e7becee2e0)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
       '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
@@ -1141,12 +1228,12 @@ snapshots:
 
   '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-user-approval@0.1.0-rc.6(dbdaba06c174c5e30e3a58edf3cc27a9)':
     dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
@@ -1306,6 +1393,8 @@ snapshots:
       fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -1526,6 +1615,10 @@ snapshots:
   isexe@2.0.0: {}
 
   jose@6.2.8: {}
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
 

--- a/scripts/multica-local-acceptance.mjs
+++ b/scripts/multica-local-acceptance.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+const ISSUE_ID = process.env.MULTICA_ISSUE_ID
+if (ISSUE_ID === undefined || ISSUE_ID.trim() === '') {
+  console.error('multica-local-acceptance: MULTICA_ISSUE_ID is not set')
+  process.exit(2)
+}
+
+const FINGERPRINT_KEY = 'local_acceptance_fingerprint'
+const LOG_LIMIT_CHARS = 8000
+
+function fail(message) {
+  console.error(`multica-local-acceptance: ${message}`)
+  process.exit(1)
+}
+
+function runMultica(args) {
+  return spawnSync('multica', args, {
+    encoding: 'utf8',
+    env: process.env,
+  })
+}
+
+function parseArgs(argv) {
+  const options = { result: undefined, log: undefined, summary: undefined }
+  const positional = []
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '--result') {
+      options.result = argv[++index]
+      continue
+    }
+    if (arg === '--log') {
+      options.log = argv[++index]
+      continue
+    }
+    if (arg === '--summary') {
+      options.summary = argv[++index]
+      continue
+    }
+    if (!arg.startsWith('--')) {
+      positional.push(arg)
+      continue
+    }
+    fail(`unsupported argument: ${arg}`)
+  }
+  options.result ??= positional[0]
+  if (options.result !== 'passed' && options.result !== 'failed') {
+    fail('usage: multica-local-acceptance.mjs --result <passed|failed> [--log <file>] [--summary <text>]')
+  }
+  return options
+}
+
+function readJsonCommand(args) {
+  const result = runMultica([...args, '--output', 'json'])
+  if (result.status !== 0) {
+    fail(`multica ${args.join(' ')} failed: ${result.stderr || result.stdout || `exit ${result.status}`}`)
+  }
+  try {
+    return JSON.parse(result.stdout)
+  } catch {
+    fail(`multica ${args.join(' ')} returned invalid JSON`)
+  }
+}
+
+function fingerprintFor(result, log, summary) {
+  const hash = createHash('sha256')
+  hash.update(result)
+  hash.update('\0')
+  hash.update(summary)
+  hash.update('\0')
+  hash.update(log)
+  return hash.digest('hex')
+}
+
+function desiredStatus(result) {
+  return result === 'passed' ? 'in_review' : 'blocked'
+}
+
+function summarizeLog(raw) {
+  if (raw.trim() === '') return ''
+  const tail = raw.length > LOG_LIMIT_CHARS
+    ? `...\n[log truncated to last ${LOG_LIMIT_CHARS} chars]\n${raw.slice(-LOG_LIMIT_CHARS)}`
+    : raw
+  return `\n<details>\n<summary>日志摘要</summary>\n\n\`\`\`text\n${tail}\n\`\`\`\n</details>\n`
+}
+
+async function readLog(logPath) {
+  if (logPath === undefined) return ''
+  try {
+    return await readFile(resolve(process.cwd(), logPath), 'utf8')
+  } catch (error) {
+    fail(`cannot read log ${logPath}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+async function writeCommentFile(content) {
+  const file = resolve(process.cwd(), '.multica', 'acceptance-comment.md')
+  await mkdir(dirname(file), { recursive: true })
+  await writeFile(file, content, 'utf8')
+  return file
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const issue = readJsonCommand(['issue', 'get', ISSUE_ID])
+  const existingFingerprint = issue.metadata?.[FINGERPRINT_KEY]
+  const currentStatus = issue.status
+  const log = await readLog(options.log)
+  const summary = options.summary ?? (options.result === 'passed'
+    ? '本地 required_checks 已全部通过。'
+    : '本地 required_checks 存在失败项。')
+  const fingerprint = fingerprintFor(options.result, log, summary)
+  const desired = desiredStatus(options.result)
+
+  if (currentStatus !== desired) {
+    const statusResult = runMultica(['issue', 'status', ISSUE_ID, desired, '--no-start'])
+    if (statusResult.status !== 0) {
+      fail(`multica issue status ${desired} failed: ${statusResult.stderr || statusResult.stdout || `exit ${statusResult.status}`}`)
+    }
+    console.log(`multica-local-acceptance: issue status -> ${desired}`)
+  } else {
+    console.log(`multica-local-acceptance: issue status already ${desired}`)
+  }
+
+  if (existingFingerprint === fingerprint) {
+    console.log('multica-local-acceptance: acceptance comment already posted for this result, skipping')
+    return
+  }
+
+  const logSection = summarizeLog(log)
+  const content = [
+    '## 本地验收结果',
+    '',
+    `- 结果：${options.result === 'passed' ? '通过' : '失败'}`,
+    `- 摘要：${summary}`,
+    `- 验收指纹：${fingerprint}`,
+    '',
+    logSection,
+  ].join('\n')
+
+  const commentFile = await writeCommentFile(content)
+  const commentResult = runMultica(['issue', 'comment', 'add', ISSUE_ID, '--content-file', commentFile])
+  if (commentResult.status !== 0) {
+    fail(`multica issue comment add failed: ${commentResult.stderr || commentResult.stdout || `exit ${commentResult.status}`}`)
+  }
+
+  const metadataResult = runMultica([
+    'issue', 'metadata', 'set', ISSUE_ID,
+    '--key', FINGERPRINT_KEY,
+    '--value', fingerprint,
+    '--type', 'string',
+  ])
+  if (metadataResult.status !== 0) {
+    fail(`multica issue metadata set ${FINGERPRINT_KEY} failed: ${metadataResult.stderr || metadataResult.stdout || `exit ${metadataResult.status}`}`)
+  }
+
+  console.log(`multica-local-acceptance: posted acceptance comment for ${ISSUE_ID}`)
+}
+
+await main()

--- a/scripts/multica-local-progress.mjs
+++ b/scripts/multica-local-progress.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const ISSUE_ID = process.env.MULTICA_ISSUE_ID
+if (ISSUE_ID === undefined || ISSUE_ID.trim() === '') {
+  console.error('multica-local-progress: MULTICA_ISSUE_ID is not set')
+  process.exit(2)
+}
+
+function fail(message) {
+  console.error(`multica-local-progress: ${message}`)
+  process.exit(1)
+}
+
+function runMultica(args) {
+  return spawnSync('multica', args, {
+    encoding: 'utf8',
+    env: process.env,
+  })
+}
+
+function setMetadata(key, value) {
+  const result = runMultica([
+    'issue', 'metadata', 'set', ISSUE_ID,
+    '--key', key,
+    '--value', value,
+    '--type', 'string',
+  ])
+  if (result.status !== 0) {
+    fail(`multica issue metadata set ${key} failed: ${result.stderr || result.stdout || `exit ${result.status}`}`)
+  }
+}
+
+async function main() {
+  const progressFile = process.argv[2] ?? '.multica/progress.jsonl'
+  const absolute = resolve(process.cwd(), progressFile)
+  let raw
+  try {
+    raw = await readFile(absolute, 'utf8')
+  } catch (error) {
+    fail(`cannot read ${progressFile}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  let phase
+  let lastArtifact
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.trim() === '') continue
+    let entry
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (typeof entry.phase === 'string' && entry.phase.trim() !== '') phase = entry.phase.trim()
+    const artifact = entry.last_artifact ?? entry.data?.last_artifact
+    if (typeof artifact === 'string' && artifact.trim() !== '') lastArtifact = artifact.trim()
+  }
+
+  if (phase === undefined && lastArtifact === undefined) {
+    fail(`no phase or last_artifact found in ${progressFile}`)
+  }
+
+  if (phase !== undefined) setMetadata('phase', phase)
+  if (lastArtifact !== undefined) setMetadata('last_artifact', lastArtifact)
+
+  console.log(`multica-local-progress: wrote ${[
+    phase === undefined ? '' : 'phase',
+    lastArtifact === undefined ? '' : 'last_artifact',
+  ].filter(Boolean).join(', ')} for ${ISSUE_ID}`)
+}
+
+await main()

--- a/src/acceptance.ts
+++ b/src/acceptance.ts
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process'
+import {
+  MAX_TOOL_OUTPUT_BYTES,
+  truncateUtf8,
+  type AcceptanceCheckResult,
+} from './protocol.js'
+
+const ACCEPTANCE_CHECK_TIMEOUT_MS = 120_000
+const ACCEPTANCE_SHELL = '/bin/sh'
+
+function combineOutput(stdout: string, stderr: string): string {
+  if (stderr === '') return stdout
+  if (stdout === '') return stderr
+  return `${stdout}\n${stderr}`
+}
+
+export function runAcceptanceCheck(command: string, cwd: string): Promise<AcceptanceCheckResult> {
+  return new Promise(resolve => {
+    const child = spawn(ACCEPTANCE_SHELL, ['-lc', command], {
+      cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let settled = false
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, ACCEPTANCE_CHECK_TIMEOUT_MS)
+
+    const finish = (result: AcceptanceCheckResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve(result)
+    }
+
+    child.stdout?.on('data', chunk => {
+      stdout += String(chunk)
+    })
+    child.stderr?.on('data', chunk => {
+      stderr += String(chunk)
+    })
+    child.on('error', error => {
+      const rendered = truncateUtf8(combineOutput(stdout, stderr), MAX_TOOL_OUTPUT_BYTES)
+      finish({
+        command,
+        exit_code: -1,
+        passed: false,
+        output: rendered.value,
+        ...rendered.truncated ? { truncated: true } : {},
+        error: { code: 'ACCEPTANCE_SPAWN_FAILED', message: error.message },
+      })
+    })
+    child.on('close', code => {
+      const rendered = truncateUtf8(combineOutput(stdout, stderr), MAX_TOOL_OUTPUT_BYTES)
+      if (timedOut) {
+        finish({
+          command,
+          exit_code: code ?? -1,
+          passed: false,
+          output: rendered.value,
+          ...rendered.truncated ? { truncated: true } : {},
+          error: { code: 'ACCEPTANCE_TIMEOUT', message: 'acceptance check exceeded the timeout' },
+        })
+        return
+      }
+      finish({
+        command,
+        exit_code: code ?? -1,
+        passed: code === 0,
+        output: rendered.value,
+        ...rendered.truncated ? { truncated: true } : {},
+      })
+    })
+  })
+}
+
+export async function runAcceptanceChecks(
+  commands: readonly string[],
+  cwd: string,
+  onCheck?: (result: AcceptanceCheckResult, index: number) => void,
+): Promise<AcceptanceCheckResult[]> {
+  const results: AcceptanceCheckResult[] = []
+  for (const [index, command] of commands.entries()) {
+    const result = await runAcceptanceCheck(command, cwd)
+    results.push(result)
+    onCheck?.(result, index)
+  }
+  return results
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -125,4 +125,4 @@ export async function installMulticaTerminalEnvironment(
   return { patched, forwarded: scrub()[TASK_TOKEN_KEY] !== undefined }
 }
 
-export { multicaTerminalEnvironment } from './task-env.js'
+export { multicaTerminalEnvironment, TASK_ISSUE_ID_KEY } from './task-env.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import {
   type RuntimeModelFrame,
   type TaskContractInput,
 } from './protocol.js'
-import { installMulticaTerminalEnvironment } from './environment.js'
+import { installMulticaTerminalEnvironment, TASK_ISSUE_ID_KEY } from './environment.js'
 import { runAcceptanceChecks } from './acceptance.js'
 
 export const name = 'multica-dsh-runtime'
@@ -88,6 +88,14 @@ function writeProgress(
     ...message === undefined ? {} : { message },
     ...data === undefined ? {} : { data },
   })
+}
+
+function applyTaskIssueEnvironment(command: ExecuteCommand): void {
+  if (command.issue_id === undefined) {
+    delete process.env[TASK_ISSUE_ID_KEY]
+    return
+  }
+  process.env[TASK_ISSUE_ID_KEY] = command.issue_id
 }
 
 function parseMode(args: readonly string[]): 'stdio' | 'probe' | 'list-models' {
@@ -557,6 +565,7 @@ async function stdio(ctx: Context): Promise<number> {
           protocolError('DUPLICATE_EXECUTE', 'this DSH process accepts exactly one execute command')
           return
         }
+        applyTaskIssueEnvironment(command)
         const active: ActiveRun = {
           command,
           firstSeq: Number.MAX_SAFE_INTEGER,

--- a/src/index.ts
+++ b/src/index.ts
@@ -618,6 +618,8 @@ async function stdio(ctx: Context): Promise<number> {
       progress: true,
       acceptance: true,
       mcp: ['stdio', 'streamable-http'],
+      issue_id: true,
+      task_contract: true,
     },
   })
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,15 @@ import {
   parseInboundCommand,
   PROTOCOL_VERSION,
   truncateUtf8,
+  type AcceptanceCheckResult,
   type ExecuteCommand,
   type McpServerInput,
   type OutboundFrame,
   type RuntimeModelFrame,
+  type TaskContractInput,
 } from './protocol.js'
 import { installMulticaTerminalEnvironment } from './environment.js'
+import { runAcceptanceChecks } from './acceptance.js'
 
 export const name = 'multica-dsh-runtime'
 export const inject = ['cmdlineArgs', 'agents', 'agentDefaultModel', 'sessions', 'llm']
@@ -69,6 +72,22 @@ function writeDiagnostic(message: string): void {
 
 function protocolError(code: string, message: string): void {
   writeFrame({ v: PROTOCOL_VERSION, type: 'protocol_error', code, message })
+}
+
+function writeProgress(
+  requestId: string,
+  phase: string,
+  data?: Record<string, unknown>,
+  message?: string,
+): void {
+  writeFrame({
+    v: PROTOCOL_VERSION,
+    type: 'progress',
+    request_id: requestId,
+    phase,
+    ...message === undefined ? {} : { message },
+    ...data === undefined ? {} : { data },
+  })
 }
 
 function parseMode(args: readonly string[]): 'stdio' | 'probe' | 'list-models' {
@@ -203,6 +222,35 @@ function renderBlock(block: ContentBlock): string {
   }
 }
 
+function taskContractPrompt(contract: TaskContractInput): string {
+  const lines = [
+    '## Task Contract',
+    `Goal: ${contract.goal}`,
+  ]
+  if (contract.acceptance !== undefined && contract.acceptance.length > 0) {
+    lines.push('Acceptance criteria:')
+    for (const [index, criterion] of contract.acceptance.entries()) {
+      lines.push(`${index + 1}. ${criterion}`)
+    }
+  }
+  if (contract.state_file !== undefined) {
+    lines.push(`State file: ${contract.state_file}`)
+  }
+  if (contract.required_checks !== undefined && contract.required_checks.length > 0) {
+    lines.push('Required checks:')
+    for (const check of contract.required_checks) {
+      lines.push(`- ${check}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function userPromptWithContract(command: ExecuteCommand): string {
+  const contract = command.task_contract
+  if (contract === undefined) return command.prompt
+  return `${taskContractPrompt(contract)}\n\n---\n\n${command.prompt}`
+}
+
 function observeSessionEvent(active: ActiveRun, session: Agent['session'], event: SessionEvent): void {
   if (active.agent?.session !== session || event.seq < active.firstSeq) return
   const requestId = active.command.request_id
@@ -275,34 +323,53 @@ async function drainContinuableSubagents(ctx: Context, agent: Agent): Promise<vo
   await subagents?.drainContinuableDescendants?.([agent])
 }
 
-function resultFromReason(active: ActiveRun): Omit<Extract<OutboundFrame, { type: 'result' }>, 'v' | 'type' | 'request_id' | 'session_id'> {
-  const reason = active.endReason
-  if (active.cancelRequested) {
-    return { status: 'cancelled', output: active.lastText, stop_reason: 'cancelled', resume_rejected: false }
-  }
-  if (reason?.kind === 'completed' || reason?.kind === 'max-tokens') {
-    return { status: 'completed', output: active.lastText, stop_reason: reason.kind, resume_rejected: false }
-  }
-  if (reason?.kind === 'aborted') {
-    return { status: 'aborted', output: active.lastText, stop_reason: reason.kind, resume_rejected: false }
-  }
-  if (reason?.kind === 'error') {
+function resultFromReason(
+  active: ActiveRun,
+  acceptance?: { passed: boolean; checks: AcceptanceCheckResult[] },
+): Omit<Extract<OutboundFrame, { type: 'result' }>, 'v' | 'type' | 'request_id' | 'session_id'> {
+  if (acceptance !== undefined && !acceptance.passed) {
     return {
       status: 'failed',
       output: active.lastText,
-      stop_reason: reason.kind,
+      stop_reason: 'acceptance-failed',
       resume_rejected: false,
-      error: { code: reason.error.code, message: reason.error.message },
+      error: {
+        code: 'ACCEPTANCE_CHECKS_FAILED',
+        message: 'one or more required acceptance checks failed',
+      },
+      acceptance,
     }
   }
-  const stopReason = reason?.kind ?? 'no-turn-result'
-  return {
-    status: 'failed',
-    output: active.lastText,
-    stop_reason: stopReason,
-    resume_rejected: false,
-    error: { code: 'DSH_TURN_FAILED', message: `DSH turn ended with ${stopReason}` },
-  }
+  const reason = active.endReason
+  const result = (() => {
+    if (active.cancelRequested) {
+      return { status: 'cancelled' as const, output: active.lastText, stop_reason: 'cancelled', resume_rejected: false }
+    }
+    if (reason?.kind === 'completed' || reason?.kind === 'max-tokens') {
+      return { status: 'completed' as const, output: active.lastText, stop_reason: reason.kind, resume_rejected: false }
+    }
+    if (reason?.kind === 'aborted') {
+      return { status: 'aborted' as const, output: active.lastText, stop_reason: reason.kind, resume_rejected: false }
+    }
+    if (reason?.kind === 'error') {
+      return {
+        status: 'failed' as const,
+        output: active.lastText,
+        stop_reason: reason.kind,
+        resume_rejected: false,
+        error: { code: reason.error.code, message: reason.error.message },
+      }
+    }
+    const stopReason = reason?.kind ?? 'no-turn-result'
+    return {
+      status: 'failed' as const,
+      output: active.lastText,
+      stop_reason: stopReason,
+      resume_rejected: false,
+      error: { code: 'DSH_TURN_FAILED', message: `DSH turn ended with ${stopReason}` },
+    }
+  })()
+  return acceptance === undefined ? result : { ...result, acceptance }
 }
 
 async function createOrResumeAgent(
@@ -358,36 +425,75 @@ async function execute(ctx: Context, active: ActiveRun): Promise<number> {
   let handle: AgentHandle | undefined
   try {
     if (!isAbsolute(active.command.cwd)) throw new Error('execute.cwd must be an absolute path')
+    const requestId = active.command.request_id
     const selection = await resolveSelection(ctx, active.command)
+    writeProgress(requestId, 'model_resolved', {
+      provider: selection.provider,
+      model: selection.model,
+      ...selection.reasoningEffort === undefined ? {} : { reasoning_effort: String(selection.reasoningEffort) },
+    })
     const created = await createOrResumeAgent(ctx, active, selection)
     handle = created.handle
     active.agent = handle.agent
     await handle.agent.whenIdle()
     active.firstSeq = handle.agent.session.seq
+    const sessionId = String(handle.agent.session.id)
+    writeProgress(requestId, created.resumed ? 'agent_resumed' : 'agent_created', { session_id: sessionId })
     writeFrame({
       v: PROTOCOL_VERSION,
       type: 'session',
-      request_id: active.command.request_id,
-      session_id: String(handle.agent.session.id),
+      request_id: requestId,
+      session_id: sessionId,
       resumed: created.resumed,
     })
+    writeProgress(requestId, 'session_ready', { session_id: sessionId })
+
+    if (active.command.task_contract !== undefined) {
+      const contract = active.command.task_contract
+      writeProgress(requestId, 'task_contract', {
+        goal: contract.goal,
+        acceptance_count: contract.acceptance?.length ?? 0,
+        required_checks_count: contract.required_checks?.length ?? 0,
+        ...contract.state_file === undefined ? {} : { state_file: contract.state_file },
+      })
+    }
+
     if (!active.cancelRequested) {
       handle.agent.followup(createUserMessage({
-        content: [{ type: 'text', text: active.command.prompt }],
+        content: [{ type: 'text', text: userPromptWithContract(active.command) }],
         source: { kind: 'user' },
       }))
+      writeProgress(requestId, 'prompt_sent')
       await handle.agent.whenIdle()
+      writeProgress(requestId, 'agent_idle')
     }
+
     await drainContinuableSubagents(ctx, handle.agent)
+    writeProgress(requestId, 'subagents_drained')
+
+    const requiredChecks = active.command.task_contract?.required_checks
+    let acceptance: { passed: boolean; checks: AcceptanceCheckResult[] } | undefined
+    if (requiredChecks !== undefined && requiredChecks.length > 0) {
+      const checks = await runAcceptanceChecks(requiredChecks, active.command.cwd, (check, index) => {
+        writeProgress(requestId, 'acceptance_check', {
+          index,
+          command: check.command,
+          exit_code: check.exit_code,
+          passed: check.passed,
+        })
+      })
+      acceptance = { passed: checks.every(check => check.passed), checks }
+    }
+
     await sessions.flush(handle.agent.session)
-    const sessionId = String(handle.agent.session.id)
-    const result = resultFromReason(active)
+    writeProgress(requestId, 'session_flushed', { session_id: sessionId })
+    const result = resultFromReason(active, acceptance)
     await handle.dispose()
     handle = undefined
     writeFrame({
       v: PROTOCOL_VERSION,
       type: 'result',
-      request_id: active.command.request_id,
+      request_id: requestId,
       session_id: sessionId,
       ...result,
     })
@@ -500,6 +606,8 @@ async function stdio(ctx: Context): Promise<number> {
       thinking: true,
       usage: true,
       tools: true,
+      progress: true,
+      acceptance: true,
       mcp: ['stdio', 'streamable-http'],
     },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import * as McpClient from '@deepseek-ai/dsh-mcp-client'
 import { SessionId, type SessionEvent, type TurnEndReason } from '@deepseek-ai/dsh-session'
 import type {} from '@deepseek-ai/cordis-plugin-loader'
 import type {} from '@deepseek-ai/dsh-agent-default-model'
+import type {} from '@deepseek-ai/dsh-agent-presets'
 import type {} from '@deepseek-ai/dsh-cmdline'
 import type {} from '@deepseek-ai/dsh-subprocess'
 import type {} from '@deepseek-ai/dsh-user-approval'
@@ -314,6 +315,8 @@ async function createOrResumeAgent(
   const selected: ModelSelectionRef = { current: selection, assembled: undefined }
   const setup = async (agentCtx: Context): Promise<void> => {
     installModelSelection(agentCtx, selected)
+    const presets = ctx.get('agentPresets')
+    if (presets !== undefined) await presets.mount(agentCtx)
     agentCtx.on('approval/request', (_request, next) => {
       if (active.cancelRequested) return Promise.resolve<ApprovalOutcome>('cancelled')
       return Promise.resolve<ApprovalOutcome>('allowed-once').catch(() => next())

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -96,6 +96,8 @@ export type OutboundFrame =
       progress: true
       acceptance: true
       mcp: ['stdio', 'streamable-http']
+      issue_id: true
+      task_contract: true
     }
   }
   | { v: typeof PROTOCOL_VERSION; type: 'probe'; runtime: 'dsh'; plugin_version: string; protocol_version: number }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -31,6 +31,22 @@ export interface StreamableHttpMcpServer extends McpServerBase {
 
 export type McpServerInput = StdioMcpServer | StreamableHttpMcpServer
 
+export interface TaskContractInput {
+  goal: string
+  acceptance?: string[]
+  state_file?: string
+  required_checks?: string[]
+}
+
+export interface AcceptanceCheckResult {
+  command: string
+  exit_code: number
+  passed: boolean
+  output: string
+  truncated?: boolean
+  error?: { code: string; message: string }
+}
+
 export interface ExecuteCommand {
   v: typeof PROTOCOL_VERSION
   type: 'execute'
@@ -41,6 +57,7 @@ export interface ExecuteCommand {
   model?: ModelSelectionInput
   reasoning_effort?: string
   mcp_servers: McpServerInput[]
+  task_contract?: TaskContractInput
 }
 
 export interface CancelCommand {
@@ -75,6 +92,8 @@ export type OutboundFrame =
       thinking: true
       usage: true
       tools: true
+      progress: true
+      acceptance: true
       mcp: ['stdio', 'streamable-http']
     }
   }
@@ -83,6 +102,14 @@ export type OutboundFrame =
   | { v: typeof PROTOCOL_VERSION; type: 'session'; request_id: string; session_id: string; resumed: boolean }
   | { v: typeof PROTOCOL_VERSION; type: 'text'; request_id: string; content: string }
   | { v: typeof PROTOCOL_VERSION; type: 'thinking'; request_id: string; content: string }
+  | {
+    v: typeof PROTOCOL_VERSION
+    type: 'progress'
+    request_id: string
+    phase: string
+    message?: string
+    data?: Record<string, unknown>
+  }
   | { v: typeof PROTOCOL_VERSION; type: 'tool_call'; request_id: string; call_id: string; name: string; arguments: string }
   | {
     v: typeof PROTOCOL_VERSION
@@ -116,6 +143,7 @@ export type OutboundFrame =
     stop_reason?: string
     resume_rejected: boolean
     error?: { code: string; message: string }
+    acceptance?: { passed: boolean; checks: AcceptanceCheckResult[] }
   }
   | { v: typeof PROTOCOL_VERSION; type: 'protocol_error'; code: string; message: string }
 
@@ -146,6 +174,14 @@ function optionalString(value: unknown, field: string): string | undefined {
 
 function stringArray(value: unknown, field: string): string[] {
   if (value === undefined) return []
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
+    throw new Error(`${field} must be an array of strings`)
+  }
+  return [...value]
+}
+
+function optionalStringArray(value: unknown, field: string): string[] | undefined {
+  if (value === undefined || value === null) return undefined
   if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
     throw new Error(`${field} must be an array of strings`)
   }
@@ -227,6 +263,22 @@ function parseMcpServers(value: unknown): McpServerInput[] {
   return servers
 }
 
+function parseTaskContract(value: unknown): TaskContractInput | undefined {
+  if (value === undefined || value === null) return undefined
+  const contract = assertRecord(value, 'task_contract')
+  assertOnlyKeys(contract, ['goal', 'acceptance', 'state_file', 'required_checks'], 'task_contract')
+  const acceptance = optionalStringArray(contract.acceptance, 'task_contract.acceptance')
+  const requiredChecks = optionalStringArray(contract.required_checks, 'task_contract.required_checks')
+  return {
+    goal: requiredString(contract.goal, 'task_contract.goal'),
+    ...acceptance === undefined ? {} : { acceptance },
+    ...optionalString(contract.state_file, 'task_contract.state_file') === undefined
+      ? {}
+      : { state_file: optionalString(contract.state_file, 'task_contract.state_file') },
+    ...requiredChecks === undefined ? {} : { required_checks: requiredChecks },
+  }
+}
+
 export function parseInboundCommand(line: string): InboundCommand {
   if (Buffer.byteLength(line) > MAX_COMMAND_BYTES) throw new Error('protocol command exceeds 8 MiB')
   let parsed: unknown
@@ -249,7 +301,7 @@ export function parseInboundCommand(line: string): InboundCommand {
   if (type === 'execute') {
     assertOnlyKeys(
       command,
-      ['v', 'type', 'request_id', 'cwd', 'prompt', 'resume_session_id', 'model', 'reasoning_effort', 'mcp_servers'],
+      ['v', 'type', 'request_id', 'cwd', 'prompt', 'resume_session_id', 'model', 'reasoning_effort', 'mcp_servers', 'task_contract'],
       'execute command',
     )
     return {
@@ -266,6 +318,9 @@ export function parseInboundCommand(line: string): InboundCommand {
         ? {}
         : { reasoning_effort: optionalString(command.reasoning_effort, 'execute.reasoning_effort') },
       mcp_servers: parseMcpServers(command.mcp_servers),
+      ...parseTaskContract(command.task_contract) === undefined
+        ? {}
+        : { task_contract: parseTaskContract(command.task_contract) },
     }
   }
   throw new Error(`unsupported protocol command type: ${type}`)

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -54,6 +54,7 @@ export interface ExecuteCommand {
   cwd: string
   prompt: string
   resume_session_id?: string
+  issue_id?: string
   model?: ModelSelectionInput
   reasoning_effort?: string
   mcp_servers: McpServerInput[]
@@ -301,7 +302,7 @@ export function parseInboundCommand(line: string): InboundCommand {
   if (type === 'execute') {
     assertOnlyKeys(
       command,
-      ['v', 'type', 'request_id', 'cwd', 'prompt', 'resume_session_id', 'model', 'reasoning_effort', 'mcp_servers', 'task_contract'],
+      ['v', 'type', 'request_id', 'cwd', 'prompt', 'resume_session_id', 'issue_id', 'model', 'reasoning_effort', 'mcp_servers', 'task_contract'],
       'execute command',
     )
     return {
@@ -313,6 +314,9 @@ export function parseInboundCommand(line: string): InboundCommand {
       ...optionalString(command.resume_session_id, 'execute.resume_session_id') === undefined
         ? {}
         : { resume_session_id: optionalString(command.resume_session_id, 'execute.resume_session_id') },
+      ...optionalString(command.issue_id, 'execute.issue_id') === undefined
+        ? {}
+        : { issue_id: optionalString(command.issue_id, 'execute.issue_id') },
       ...parseModel(command.model) === undefined ? {} : { model: parseModel(command.model) },
       ...optionalString(command.reasoning_effort, 'execute.reasoning_effort') === undefined
         ? {}

--- a/src/task-env.ts
+++ b/src/task-env.ts
@@ -1,9 +1,25 @@
-/** Return the one credential DSH child tools may receive from Multica. */
+const TASK_TOKEN_KEY = 'MULTICA_TOKEN'
+export const TASK_ISSUE_ID_KEY = 'MULTICA_ISSUE_ID'
+
+/**
+ * Return the task identity Multica may expose to DSH child tools.
+ *
+ * The token is the only credential passed through: it must be server-minted
+ * (`mat_`) and never a user PAT. The issue id is not a credential, but is
+ * still gated to a non-empty value so an absent id leaves the environment
+ * untouched rather than exporting `MULTICA_ISSUE_ID=undefined`.
+ */
 export function multicaTerminalEnvironment(
   environment: NodeJS.ProcessEnv,
 ): Record<string, string> {
-  const token = environment.MULTICA_TOKEN
-  return token?.startsWith('mat_') === true && token.length > 4
-    ? { MULTICA_TOKEN: token }
-    : {}
+  const result: Record<string, string> = {}
+  const token = environment[TASK_TOKEN_KEY]
+  if (token?.startsWith('mat_') === true && token.length > 4) {
+    result[TASK_TOKEN_KEY] = token
+  }
+  const issueId = environment[TASK_ISSUE_ID_KEY]
+  if (issueId !== undefined && issueId.trim() !== '') {
+    result[TASK_ISSUE_ID_KEY] = issueId
+  }
+  return result
 }

--- a/tests/acceptance.test.ts
+++ b/tests/acceptance.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { runAcceptanceCheck, runAcceptanceChecks } from '../src/acceptance.js'
+
+describe('runAcceptanceCheck', () => {
+  it('reports a successful command as passed', async () => {
+    const result = await runAcceptanceCheck('exit 0', process.cwd())
+    expect(result.passed).toBe(true)
+    expect(result.exit_code).toBe(0)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('reports a failing command with its exit code', async () => {
+    const result = await runAcceptanceCheck('echo nope && exit 3', process.cwd())
+    expect(result.passed).toBe(false)
+    expect(result.exit_code).toBe(3)
+    expect(result.output).toContain('nope')
+  })
+})
+
+describe('runAcceptanceChecks', () => {
+  it('runs checks in order and invokes the callback per check', async () => {
+    const seen: number[] = []
+    const results = await runAcceptanceChecks(['exit 0', 'exit 0'], process.cwd(), (result, index) => {
+      seen.push(index)
+      expect(result.passed).toBe(true)
+    })
+    expect(results).toHaveLength(2)
+    expect(seen).toEqual([0, 1])
+  })
+})

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -17,6 +17,23 @@ describe('Multica terminal environment', () => {
     })).toEqual({ MULTICA_TOKEN: 'mat_task-token' })
   })
 
+  it('forwards a non-empty issue id alongside the task token', () => {
+    expect(multicaTerminalEnvironment({
+      MULTICA_TOKEN: 'mat_task-token',
+      MULTICA_ISSUE_ID: '049c05e8-70ed-4c43-8ffa-9a313bb94c50',
+    })).toEqual({
+      MULTICA_TOKEN: 'mat_task-token',
+      MULTICA_ISSUE_ID: '049c05e8-70ed-4c43-8ffa-9a313bb94c50',
+    })
+  })
+
+  it('does not forward an empty issue id', () => {
+    expect(multicaTerminalEnvironment({
+      MULTICA_TOKEN: 'mat_task-token',
+      MULTICA_ISSUE_ID: '',
+    })).toEqual({ MULTICA_TOKEN: 'mat_task-token' })
+  })
+
   it('does not forward a user PAT or arbitrary credentials', () => {
     expect(multicaTerminalEnvironment({
       MULTICA_TOKEN: 'mul_user-token',
@@ -33,6 +50,7 @@ describe('parseInboundCommand', () => {
       request_id: 'request-1',
       cwd: '/work',
       prompt: 'run tests',
+      issue_id: '049c05e8-70ed-4c43-8ffa-9a313bb94c50',
       model: { provider: 'deepseek-official', id: 'deepseek-v4-flash', reasoning_effort: 'high' },
       reasoning_effort: 'max',
       mcp_servers: [{
@@ -48,6 +66,7 @@ describe('parseInboundCommand', () => {
       request_id: 'request-1',
       cwd: '/work',
       prompt: 'run tests',
+      issue_id: '049c05e8-70ed-4c43-8ffa-9a313bb94c50',
       model: { provider: 'deepseek-official', id: 'deepseek-v4-flash', reasoning_effort: 'high' },
       reasoning_effort: 'max',
       mcp_servers: [{

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -60,6 +60,55 @@ describe('parseInboundCommand', () => {
     })
   })
 
+  it('parses an optional task contract', () => {
+    expect(parseInboundCommand(JSON.stringify({
+      v: 1,
+      type: 'execute',
+      request_id: 'request-2',
+      cwd: '/work',
+      prompt: 'implement feature',
+      task_contract: {
+        goal: 'make tests pass',
+        acceptance: ['tests pass'],
+        state_file: '.multica/progress.jsonl',
+        required_checks: ['pnpm test'],
+      },
+    }))).toEqual({
+      v: PROTOCOL_VERSION,
+      type: 'execute',
+      request_id: 'request-2',
+      cwd: '/work',
+      prompt: 'implement feature',
+      mcp_servers: [],
+      task_contract: {
+        goal: 'make tests pass',
+        acceptance: ['tests pass'],
+        state_file: '.multica/progress.jsonl',
+        required_checks: ['pnpm test'],
+      },
+    })
+  })
+
+  it('rejects malformed task contract fields', () => {
+    expect(() => parseInboundCommand(JSON.stringify({
+      v: 1,
+      type: 'execute',
+      request_id: 'request-3',
+      cwd: '/work',
+      prompt: 'hello',
+      task_contract: { goal: 123 },
+    }))).toThrow('task_contract.goal must be a non-empty string')
+
+    expect(() => parseInboundCommand(JSON.stringify({
+      v: 1,
+      type: 'execute',
+      request_id: 'request-4',
+      cwd: '/work',
+      prompt: 'hello',
+      task_contract: { goal: 'ok', unexpected: true },
+    }))).toThrow('task_contract contains unsupported field')
+  })
+
   it('defaults the MCP list and rejects unknown fields', () => {
     expect(parseInboundCommand(JSON.stringify({
       v: 1,


### PR DESCRIPTION
## Summary

Adds the local-side closed-loop plumbing for the DSH runtime on Multica:

- Mount the DSH agent presets into the runtime.
- Add a task-contract input channel, structured `progress`/`acceptance` reporting, and a deterministic acceptance gate.
- Forward `issue_id` into the runtime and add scripts that write progress/acceptance back through the Multica CLI.

## Changes

- `package.json`: add DSH agent presets wiring and the local writeback scripts.
- `src/index.ts`: mount presets, surface the task contract, emit progress frames, and forward `issue_id`.
- `src/protocol.ts`: add `task_contract` and `progress`/`acceptance` fields.
- `src/acceptance.ts`: add an acceptance check runner with deterministic `required_checks` gating.
- `scripts/multica-local-progress.mjs` / `scripts/multica-local-acceptance.mjs`: write execution progress and acceptance results back to Multica from inside the task.
- `docs/task-local-writeback.md`: document the in-task local writeback flow.
- Tests for the protocol additions and acceptance runner.

## Related

- Platform adapter change: https://github.com/multica-ai/multica/pull/7169
