### PR TITLE
fix: reach the workspace dsh-subprocess instance the shell tools scrub through

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -81,20 +81,52 @@ export function exemptTaskTokenOn(
  * Resolve the dsh-subprocess instance the DSH launcher itself loaded, so the
  * exemption reaches the scrub that actually runs no matter how this plugin was
  * installed.
+ *
+ * The launcher usually cannot resolve `@deepseek-ai/dsh-subprocess` directly:
+ * the shell/subprocess packages that call `scrubbedParentEnv()` live inside
+ * the DSH base bundle, and each deployment links them differently (npm
+ * installs, pnpm workspaces, a git checkout with per-package node_modules
+ * links). Resolution therefore walks the chain of packages the launcher *can*
+ * see — `dsh-base`, then the local subprocess provider its bundle links — and
+ * imports the same `dsh-subprocess` file the shell tools resolve, so the
+ * module cache returns the very instance that scrubs tool environments.
  * @param entrypoint - the launcher script, normally `process.argv[1]`.
  * @returns the launcher's module, or undefined when it cannot be reached.
  */
-async function hostScrubModule(entrypoint: string | undefined): Promise<ScrubModule | undefined> {
-  if (entrypoint === undefined || entrypoint.trim() === '') return undefined
+export async function resolveScrubModule(entrypoint: string): Promise<ScrubModule | undefined> {
   try {
     // realpathSync is load-bearing: `dsh` is normally a bin symlink, Node
     // leaves argv[1] as the link, and a link in a bare bin directory resolves
     // no node_modules chain of its own.
-    const specifier = createRequire(realpathSync(entrypoint)).resolve('@deepseek-ai/dsh-subprocess')
+    const requireFromLauncher = createRequire(realpathSync(entrypoint))
+
+    // 1. direct resolution — works when the launcher's own node_modules chain
+    //    reaches dsh-subprocess (npm-installed DSH).
+    let specifier: string | undefined
+    try {
+      specifier = requireFromLauncher.resolve('@deepseek-ai/dsh-subprocess')
+    } catch {
+      // 2. workspace deployments: the launcher sees dsh-base, whose bundle
+      //    links dsh-subprocess-local, which imports dsh-subprocess. Resolving
+      //    through those links lands on the same file the shell tools load.
+      const requireFromBase = createRequire(realpathSync(requireFromLauncher.resolve('@deepseek-ai/dsh-base')))
+      try {
+        specifier = requireFromBase.resolve('@deepseek-ai/dsh-subprocess')
+      } catch {
+        const requireFromLocal = createRequire(realpathSync(requireFromBase.resolve('@deepseek-ai/dsh-subprocess-local')))
+        specifier = requireFromLocal.resolve('@deepseek-ai/dsh-subprocess')
+      }
+    }
+    if (specifier === undefined) return undefined
     return await import(pathToFileURL(specifier).href) as ScrubModule
   } catch {
     return undefined
   }
+}
+
+async function hostScrubModule(entrypoint: string | undefined): Promise<ScrubModule | undefined> {
+  if (entrypoint === undefined || entrypoint.trim() === '') return undefined
+  return resolveScrubModule(entrypoint)
 }
 
 /**

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { existsSync } from 'node:fs'
 import type { Context } from '@deepseek-ai/cordis'
 import { scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
-import { exemptTaskTokenOn, installMulticaTerminalEnvironment } from '../src/environment.js'
+import { exemptTaskTokenOn, installMulticaTerminalEnvironment, resolveScrubModule } from '../src/environment.js'
 
 /** DSH's own credential-name matcher, cloned so a test never patches the real one. */
 function scrubPattern(): RegExp {
@@ -109,4 +110,34 @@ describe('installMulticaTerminalEnvironment', () => {
     expect(report).toEqual({ patched: 1, forwarded: true })
     ctx.dispose()
   })
+})
+
+describe('resolveScrubModule', () => {
+  // The workspace checkout this bridge runs against: the launcher resolves
+  // dsh-subprocess only through dsh-base → dsh-subprocess-local. Skipped on
+  // machines without that checkout so the suite stays portable.
+  const LAUNCHER = '/home/llm/deepseek-harness/apps/cli/lib/bin.js'
+
+  it.runIf(existsSync(LAUNCHER))(
+    'reaches the same dsh-subprocess instance the shell tools spawn through',
+    async () => {
+      vi.stubEnv('MULTICA_TOKEN', 'mat_task-token')
+      vi.stubEnv('DEEPSEEK_API_KEY', 'provider-secret')
+
+      const host = await resolveScrubModule(LAUNCHER)
+      expect(host).toBeDefined()
+
+      // The MUL-6186 regression in this deployment: patching the bridge's own
+      // npm copy left the workspace copy the bash tool scrubs through intact,
+      // so MULTICA_TOKEN never reached in-task `multica` calls. Patching the
+      // resolved launcher instance must make *its* scrub keep the task token.
+      expect(host!.scrubbedParentEnv().MULTICA_TOKEN).toBeUndefined()
+      const { dispose } = exemptTaskTokenOn([host!.SENSITIVE_ENV_PATTERN])
+      const env = host!.scrubbedParentEnv()
+      expect(env.MULTICA_TOKEN).toBe('mat_task-token')
+      expect(env.DEEPSEEK_API_KEY).toBeUndefined()
+      dispose()
+      expect(host!.scrubbedParentEnv().MULTICA_TOKEN).toBeUndefined()
+    },
+  )
 })


### PR DESCRIPTION
## What does this PR do?

In git-checkout (workspace) DSH deployments, the task-scoped `MULTICA_TOKEN` never reaches the agent shell: `hostScrubModule()` resolves `@deepseek-ai/dsh-subprocess` directly from the launcher script, which cannot see that package in a workspace layout, so the exemption silently falls back to patching only the bridge's own npm copy of the scrub matcher. The bash tool scrubs through the **workspace copy** (`dsh-base → dsh-subprocess-local → dsh-subprocess`) — a different module instance that is never patched — so `MULTICA_TOKEN` is still stripped and every in-task `multica` command is refused with `agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token`. Because the boot probe self-tests the patched bridge copy when the host is unresolvable, the intended fail-loud diagnostic never fires.

This PR makes the exemption reach the instance that actually runs: resolution now walks the chain of packages the launcher *can* reach (`launcher → @deepseek-ai/dsh-base → @deepseek-ai/dsh-subprocess-local → @deepseek-ai/dsh-subprocess`) and imports the same file the shell tools load, so Node's module cache returns the very instance that scrubs tool environments. The boot probe then tests the real host instance, restoring the fail-loud diagnostic for any future resolution gap.

## Related Issue

Closes #6

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `src/environment.ts` — new exported `resolveScrubModule(entrypoint)`: tries direct `@deepseek-ai/dsh-subprocess` resolution first (npm-installed DSH), then falls back to the workspace chain `dsh-base → dsh-subprocess-local → dsh-subprocess`. `hostScrubModule` delegates to it.
- `tests/environment.test.ts` — regression test that resolves the real launcher on this machine, asserts the resolved instance's scrub strips `MULTICA_TOKEN` before patching and keeps it (plus still strips `DEEPSEEK_API_KEY`) after, then restores it. Skipped automatically on machines without the checkout.

## How to Test

1. On a git-checkout DSH deployment (launcher + workspace `dsh-subprocess`), start the bridge with a task-scoped token:
   ```bash
   MULTICA_TOKEN=mat_<task-token> dsh --profile multica --stdio
   ```
   The boot report is now `{patched: 2, forwarded: true}` (bridge copy + host workspace copy).
2. In a task, run `multica <command>` from the agent's bash tool — it is no longer refused for want of a task token; `env` in the shell shows `MULTICA_TOKEN`.
3. Confirm other credentials are still scrubbed (`env` shows no `DEEPSEEK_API_KEY`, etc.).
4. `pnpm check` passes locally (typecheck + 15 tests + build); `dsh --profile multica --probe` still returns `protocol_version: 1`.

Reproduction before the fix (from #6): agent's first `multica` call fails with `agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token`; shell `env` shows all `MULTICA_*` vars except `MULTICA_TOKEN`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change — the token-forwarding contract in `environment.ts` (exempt exactly `MULTICA_TOKEN`, nothing else) is unchanged; the fix only makes `hostScrubModule` reach the instance the shell tools actually scrub through, which is what MUL-6186's original patch intended but could not resolve in workspace layouts.
- [x] I have run tests locally and they pass (`pnpm check`: typecheck, 15/15 tests, build)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A)
- [x] I have updated relevant documentation to reflect my changes (README unchanged; fix is internal)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against conventions (N/A)
- [x] I have considered and documented any risks above — none: resolution falls back to the existing single-instance patch when the host cannot be resolved, and the probe now reports the true state instead of a false positive
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** DeepSeek Harness agent (this coding session)

**Prompt / approach:**
The issue was investigated end-to-end: verified the daemon injects `MULTICA_TOKEN` into the runtime process, traced the bash tool's env construction to `scrubbedParentEnv()` in the workspace copy of `@deepseek-ai/dsh-subprocess`, confirmed the bridge's `hostScrubModule` resolution fails from the launcher in this deployment, and validated the fix against the real module instance before committing (probe report `{patched: 2, forwarded: true}`, host scrub keeps `MULTICA_TOKEN` and strips other credentials). A regression test was added using the real launcher path.
